### PR TITLE
Enable manual triggering of "Build Main"

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,6 +1,7 @@
 name: Build Main
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
This PR enables manual triggering of the "Build Main" workflow (see [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)).