### PR TITLE
Remove Python3.7 support

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: Free for non-commercial use",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
     description="Cytoplasm parameterization using spherical harmonics",


### PR DESCRIPTION
**Description**
Per a support request to the SW team in Slack by Matheus, this PR is intended to drop support for Python 3.7. This specifically drops 3.7 from the GitHub test specification to avoid those running and causing a failing build.
